### PR TITLE
OIDC-12 BREAKING provide failure reason to unauthorized handler fn

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ See [the demo](src/dev/com/yetanalytics/pedestal_oidc/service.clj) for a simple 
 
 Give `com.yetanalytics.pedestal-oidc.interceptor/decode-interceptor` a function that returns a map of JWKS key IDs to the keys themselves and place it in your interceptor chain. Decoded claims will be placed on the request at `:com.yetanalytics.pedestal-oidc/claims`.
 
+#### Failures
+
+By default the `decode-interceptor` will respond to any failure with a 401. You can customize this behavior by providing a `:unauthorized` keyword arg which is a function that will recieve the pedestal context, a failure keyword and possibly an exception. The possible failure keywords are:
+
+* `:header-missing` - The `Authorization` header (or whatever is provided for `check-header`) is not present. No exception.
+* `:header-invalid` - The header does not start with `Bearer `. No exception.
+* `:kid-not-found` - The indicated public key is not found by ID. An exception is passed with ex-data containing the `:kid`
+* `:validation` - The token failed unsigning with `buddy-sign`. The provided exception contains the `:cause` in its ex-data.
+* `:unknown` - An unknown exception was thrown. See the provided exception for more info.
+
+The default `:unauthorized` function will add the failure keyword to the context as `:com.yetanalytics.pedestal-oidc/failure`. By default exceptions will not be retained.
+
 ### Getting Keysets
 
 `com.yetanalytics.pedestal-oidc.jwt/get-keyset` will attempt to fetch a valid keyset from the given `jwks-uri`. How this is stored/cached is up to the lib consumer.

--- a/src/dev/com/yetanalytics/pedestal_oidc/service.clj
+++ b/src/dev/com/yetanalytics/pedestal_oidc/service.clj
@@ -32,7 +32,11 @@
                        ;; read the jwks uri
                        (get "jwks_uri")
                        ;; go get the keyset
-                       jwt/get-keyset)))
+                       jwt/get-keyset))
+
+                 ;; If you want to handle failures differently:
+                 ;; :unauthorized (fn [ctx failure & [?ex]] ...)
+                 )
                 `echo-claims]]})
 
 (def service {:env :prod


### PR DESCRIPTION
[OIDC-12] Currently we provide the pedestal context and possibly an exception to the `unauthorized` function arg to `decode-interceptor`, with no indication of what went wrong.

This breaking change adds an additional arg to the `unauthorized` function, `failure` which is always present and attempts to describe what went wrong. See docs on branch: https://github.com/yetanalytics/pedestal-oidc/blob/OIDC-12/README.md#failures

[OIDC-12]: https://yet.atlassian.net/browse/OIDC-12?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ