### PR TITLE
OIDC-14 Add retry capability

### DIFF
--- a/src/dev/com/yetanalytics/pedestal_oidc/service.clj
+++ b/src/dev/com/yetanalytics/pedestal_oidc/service.clj
@@ -23,7 +23,7 @@
                  ;; How you retrieve/cache the config & keyset is up to you
                  ;; the interceptor gives this function the context in case
                  ;; you need access to something in there to get it
-                 (fn [ctx_]
+                 (fn [ctx]
                    (-> "http://0.0.0.0:8080/auth/realms/test" ;; the issuer
                        ;; Derive the config uri
                        disco/issuer->config-uri
@@ -35,7 +35,17 @@
                        jwt/get-keyset))
 
                  ;; If you want to handle failures differently:
-                 ;; :unauthorized (fn [ctx failure & [?ex]] ...)
+
+                 ;; :unauthorized
+                 ;; (fn [{attempt ::attempt
+                 ;;       :as ctx
+                 ;;       :or {attempt 0}} failure & [?ex]]
+                 ;;   (println "fail!" failure)
+                 ;;   (if (< attempt 5)
+                 ;;     (-> ctx
+                 ;;         (update ::attempt (fnil inc 0))
+                 ;;         i/retry-decode)
+                 ;;     (i/default-unauthorized ctx failure ?ex)))
                  )
                 `echo-claims]]})
 


### PR DESCRIPTION
[OIDC-14] Provide the `retry-decode` function to re-enqueue the interceptor. This is useful if you've refreshed a cache or some such and would like to re-attempt the unsigning of the token.

[OIDC-14]: https://yet.atlassian.net/browse/OIDC-14?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ