### PR TITLE
OIDC-15 handle keyset errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ By default the `decode-interceptor` will respond to any failure with a 401. You 
 * `:header-invalid` - The header does not start with `Bearer `. No exception.
 * `:kid-not-found` - The indicated public key is not found by ID. An exception is passed with ex-data containing the `:kid`
 * `:validation` - The token failed unsigning with `buddy-sign`. The provided exception contains the `:cause` in its ex-data.
+* `:keyset-invalid` - The keyset function failed to return a map.
+* `:keyset-error` - (sync only) the keyset function threw an unhandled error.
 * `:unknown` - An unknown exception was thrown. See the provided exception for more info.
 
 The default `:unauthorized` function will add the failure keyword to the context as `:com.yetanalytics.pedestal-oidc/failure`. By default exceptions will not be retained.

--- a/src/test/com/yetanalytics/pedestal_oidc/interceptor_test.clj
+++ b/src/test/com/yetanalytics/pedestal_oidc/interceptor_test.clj
@@ -50,7 +50,21 @@
           {:request {:headers {}}}                               :header-missing
           {:request {:headers {"authorization" ""}}}             :header-invalid
           {:request {:headers {"authorization" bad-header}}}     :token-invalid
-          {:request {:headers {"authorization" unknown-header}}} :kid-not-found)))
+          {:request {:headers {"authorization" unknown-header}}} :kid-not-found))
+      (testing "keyset failures"
+        (let [{:keys [enter]} (decode-interceptor
+                               #(throw (ex-info "uh oh"
+                                                {:type ::uh-oh})))]
+          (is (= :keyset-error
+                 (get
+                  (enter {:request {:headers {"authorization" auth-header}}})
+                  :com.yetanalytics.pedestal-oidc/failure))))
+        (let [{:keys [enter]} (decode-interceptor
+                               (constantly nil))]
+          (is (= :keyset-invalid
+                 (get
+                  (enter {:request {:headers {"authorization" auth-header}}})
+                  :com.yetanalytics.pedestal-oidc/failure))))))
     (testing "decodes, async"
       (let [{:keys [enter]} (decode-interceptor
                              (fn [_]


### PR DESCRIPTION
[OIDC-15] The lib doesn't handle thrown errors in the keyset function. This PR adds this functionality, so errors are described by key and passed to unauthorized