### PR TITLE
OIDC-16 Flexible keysets - map or function

### DIFF
--- a/src/lib/com/yetanalytics/pedestal_oidc/jwt.clj
+++ b/src/lib/com/yetanalytics/pedestal_oidc/jwt.clj
@@ -8,8 +8,12 @@
 (s/def ::kid string?)
 
 (s/def ::keyset
-  (s/map-of ::kid
-            bkeys/public-key?))
+  (s/or :map (s/map-of ::kid
+                       bkeys/public-key?)
+        ;; Keyset can be a function that takes the :kid
+        :function (s/fspec
+                   :args (s/cat :kid ::kid)
+                   :ret (s/nilable bkeys/public-key?))))
 
 (s/fdef get-keyset
   :args (s/cat :jwks-uri string?)
@@ -44,7 +48,7 @@
   (jwt/unsign
    jwt
    (fn [{:keys [kid]}]
-     (or (get keyset kid)
+     (or (keyset kid)
          (throw (ex-info "JWT Key ID Not Found"
                          {:type ::kid-not-found
                           :kid kid}))))


### PR DESCRIPTION
[OIDC-16] If we allow the keyset to be a map _or_ a function, cache decisions can be simpler