### PR TITLE
Pass through access token

### DIFF
--- a/src/lib/com/yetanalytics/pedestal_oidc/interceptor.clj
+++ b/src/lib/com/yetanalytics/pedestal_oidc/interceptor.clj
@@ -30,12 +30,13 @@
       (if (cstr/starts-with? auth-header "Bearer ")
         (let [access-token (subs auth-header 7)]
           (try
-            (assoc-in ctx
-                      [:request
-                       :com.yetanalytics.pedestal-oidc/claims]
-                      (jwt/unsign
-                       keyset
-                       access-token))
+            (-> ctx
+                (assoc :com.yetanalytics.pedestal-oidc/token access-token)
+                (assoc-in [:request
+                           :com.yetanalytics.pedestal-oidc/claims]
+                          (jwt/unsign
+                           keyset
+                           access-token)))
             (catch clojure.lang.ExceptionInfo exi
               (case (some-> exi
                             ex-data

--- a/src/test/com/yetanalytics/pedestal_oidc/interceptor_test.clj
+++ b/src/test/com/yetanalytics/pedestal_oidc/interceptor_test.clj
@@ -18,7 +18,8 @@
     (testing "decodes, sync"
       (let [{:keys [enter]} (decode-interceptor
                              get-keyset-fn)]
-        (is (= {:request
+        (is (= {:com.yetanalytics.pedestal-oidc/token "eyJhbGciOiJSUzI1NiIsImtpZCI6ImZvbyJ9.eyJiYXIiOiJiYXoifQ.hFdq5YhGabJUl9gemxt7lmNMEDyTL7A3z_i1qk-1NdU48yljsLTfa7tsZQuHtQzmJVJxBDX7GJ4f-0a_b6NMuIZ2ekYUiR__S4pzElaK0jP0DECV8Z54fo0Uq3LhhItF0BwjgjIKYKc1a8Sk5y9W9gRrFAcFbQr5e8GUO5vRjqA"
+                :request
                 {:headers
                  {"authorization"
                   "Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6ImZvbyJ9.eyJiYXIiOiJiYXoifQ.hFdq5YhGabJUl9gemxt7lmNMEDyTL7A3z_i1qk-1NdU48yljsLTfa7tsZQuHtQzmJVJxBDX7GJ4f-0a_b6NMuIZ2ekYUiR__S4pzElaK0jP0DECV8Z54fo0Uq3LhhItF0BwjgjIKYKc1a8Sk5y9W9gRrFAcFbQr5e8GUO5vRjqA"},
@@ -70,7 +71,8 @@
                              (fn [_]
                                (a/go (get-keyset-fn)))
                              :async? true)]
-        (is (= {:request
+        (is (= {:com.yetanalytics.pedestal-oidc/token "eyJhbGciOiJSUzI1NiIsImtpZCI6ImZvbyJ9.eyJiYXIiOiJiYXoifQ.hFdq5YhGabJUl9gemxt7lmNMEDyTL7A3z_i1qk-1NdU48yljsLTfa7tsZQuHtQzmJVJxBDX7GJ4f-0a_b6NMuIZ2ekYUiR__S4pzElaK0jP0DECV8Z54fo0Uq3LhhItF0BwjgjIKYKc1a8Sk5y9W9gRrFAcFbQr5e8GUO5vRjqA"
+                :request
                 {:headers
                  {"authorization"
                   "Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6ImZvbyJ9.eyJiYXIiOiJiYXoifQ.hFdq5YhGabJUl9gemxt7lmNMEDyTL7A3z_i1qk-1NdU48yljsLTfa7tsZQuHtQzmJVJxBDX7GJ4f-0a_b6NMuIZ2ekYUiR__S4pzElaK0jP0DECV8Z54fo0Uq3LhhItF0BwjgjIKYKc1a8Sk5y9W9gRrFAcFbQr5e8GUO5vRjqA"},


### PR DESCRIPTION
Pass the access token through so it doesn't need to be pulled out of the header again. Put it directly on context