### PR TITLE
OIDC-18 relax issuer->config-uri

### DIFF
--- a/src/lib/com/yetanalytics/pedestal_oidc/discovery.clj
+++ b/src/lib/com/yetanalytics/pedestal_oidc/discovery.clj
@@ -11,9 +11,10 @@
 
 (defn issuer->config-uri
   [issuer]
-  (assert (not (cstr/ends-with? issuer "/")) "Issuer cannot contain trailing slash/")
-  (format "%s/.well-known/openid-configuration"
-          issuer))
+  (str issuer
+       (when-not (cstr/ends-with? issuer "/")
+         "/")
+       ".well-known/openid-configuration"))
 
 (s/fdef get-openid-config
   :args (s/cat :config-uri string?)

--- a/src/lib/com/yetanalytics/pedestal_oidc/interceptor.clj
+++ b/src/lib/com/yetanalytics/pedestal_oidc/interceptor.clj
@@ -77,6 +77,7 @@
     :unauthorized - A function that will receive the context map to handle a 401,
       a failure keyword and possibly an exception.
     :check-header - the header to check for the access token.
+    :unsign-opts - extra options to pass to buddy-sign.
   "
   [get-keyset-fn
    & {:keys [required?


### PR DESCRIPTION
Instead of throwing an assertion error, just add the slash as-needed.