### PR TITLE
Update Clojars deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
           clojars-deploy-token: ${{ secrets.CLOJARS_PASSWORD }}
 
     - name: Craft Draft Release
-      uses: softprops/action-gh-release@v1 # TODO: Update when new version is released 
+      uses: softprops/action-gh-release@v1
       with:
         draft: true
         files: target/pedestal-oidc-${{ steps.version.outputs.version }}.jar

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
       run: echo version=${GITHUB_REF#refs\/tags\/v} >> $GITHUB_OUTPUT
 
     - name: Build and deploy to Clojars
-      uses: yetanalytics/actions/deploy-clojars@v0.0.4
+      uses: yetanalytics/action-deploy-clojars@v1
       with:
           artifact-id: 'pedestal-oidc'
           src-dirs: '["src/lib"]'


### PR DESCRIPTION
Update the deploy workflow to use the latest version of action-deploy-clojars, in order to fix the now-broken Clojars deployment pipeline.